### PR TITLE
Fix to optimize array creation using np.tile instead of list multiplication

### DIFF
--- a/hello_mypyc/sample_numpy.py
+++ b/hello_mypyc/sample_numpy.py
@@ -2,10 +2,10 @@ import numpy as np
 
 def calculate_with_numpy(batch_size=10):
     input_row_dict = {
-        "ad_click_cnt": np.array([10, 20, 0, 30]) * batch_size,
-        "ad_impression_cnt": np.array([5, 0, 15, 25]) * batch_size,
-        "ad2_click_cnt": np.array([10, 20, 0, 30]) * batch_size,
-        "ad2_impression_cnt": np.array([5, 0, 15, 25]) * batch_size,
+        "ad_click_cnt": np.tile([10, 20, 0, 30], batch_size),
+        "ad_impression_cnt": np.tile([5, 0, 15, 25], batch_size),
+        "ad2_click_cnt": np.tile([10, 20, 0, 30], batch_size),
+        "ad2_impression_cnt": np.tile([5, 0, 15, 25], batch_size),
     }
 
     # numpy 연산을 통해 벡터화된 방식으로 전환


### PR DESCRIPTION
- `np.array([10, 20, 0, 30]) * batch_size` 로는 array 사이즈가 의도된대로 증가하지 않습니다
- `np.array([10, 20, 0, 30]) * batch_size`를 `np.tile([10, 20, 0, 30], batch_size)`로 바꿔서 batch size 만큼 증가하고, NumPy 배열 생성 전에 불필요한 Python 리스트 곱셈을 방지합니다